### PR TITLE
Handle links to specifics downloads

### DIFF
--- a/resources/public/assets/icons/link.svg
+++ b/resources/public/assets/icons/link.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="24px" height="24px" stroke-width="1.5" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" color="currentColor">
+<path d="M14 11.998C14 9.506 11.683 7 8.857 7H7.143C4.303 7 2 9.238 2 11.998c0 2.378 1.71 4.368 4 4.873a5.3 5.3 0 001.143.124" stroke="#000000" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path><path d="M10 11.998c0 2.491 2.317 4.997 5.143 4.997h1.714c2.84 0 5.143-2.237 5.143-4.997 0-2.379-1.71-4.37-4-4.874A5.304 5.304 0 0016.857 7" stroke="#000000" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+</svg>

--- a/resources/public/assets/local.css
+++ b/resources/public/assets/local.css
@@ -74,7 +74,8 @@ button {
 }
 
 .job-container:target {
-    background-color: deepskyblue;
+    background-color: lemonchiffon;
+    transition: background-color .2s ease-in;
 } 
 
 .job-head {

--- a/resources/public/assets/local.css
+++ b/resources/public/assets/local.css
@@ -73,6 +73,10 @@ button {
     padding: 1em 0;
 }
 
+.job-container:target {
+    background-color: deepskyblue;
+} 
+
 .job-head {
     display: flex;
     align-items: flex-start;

--- a/resources/public/assets/local.css
+++ b/resources/public/assets/local.css
@@ -70,7 +70,8 @@ button {
 }
 
 .job-container {
-    padding: 1em 0;
+    padding: 1em;
+    border-radius: 1em;
 }
 
 .job-container:target {

--- a/src/ytdlui/view.clj
+++ b/src/ytdlui/view.clj
@@ -57,6 +57,7 @@
    [:div
     (for [job jobs]
       [:div.job-container
+       {:id (format "job-%s" (:job_id job))}
        [:div.job-head
         [:div.job-status-icon
          {:style (format "background-color: %s;" (status-color (:status job)))}
@@ -64,6 +65,11 @@
                                :src (format "/assets/icons/%s.svg" (status-icon (:status job)))}]]
         [:div [:a {:href (:url job)} (or (:title job) (:url job))]]]
        [:div.job-actions
+        (when (#{"done"} (:status job))
+          [:a
+           {:href (format "/#job-%s" (:job_id job))}
+           [:div.job-action
+            [ :span "🔗 Link"]]])
         (when (or (:stdout job) (:stderr job) (:exception job))
           [:a
            {:href (format "/job/%d/logs" (:job_id job))}

--- a/src/ytdlui/view.clj
+++ b/src/ytdlui/view.clj
@@ -69,7 +69,7 @@
           [:a
            {:href (format "/#job-%s" (:job_id job))}
            [:div.job-action
-            [ :span "🔗 Link"]]])
+            [:img {:src "assets/icons/link.svg"}] "Link"]])
         (when (or (:stdout job) (:stderr job) (:exception job))
           [:a
            {:href (format "/job/%d/logs" (:job_id job))}


### PR DESCRIPTION
The idea is to be able to send a link that goes to a specific download that you already added. This would avoid messages like "Open ytdlui and ctrlf+f "my track".

For this 3 things need to happen:

1. Adding an `id` attribute to the job-container in the HTML, so any link with `job-<job-id>` goes to the correct place
2. Adding a `link` button to obtain this link with anchor directly from the UI. I added a _Link_ button next to the _Logs_ and _Download_ button in each job. I also used a unicode character for the icon. Can totally be reworked.
3. Having a kind of visual feedback when coming from a job-specific link. This is not really necessary, but given the absence of a _Download detail page_, it felt a bit weird to link to the list of all jobs and just having the window scroll as the only indication that you need to look at one in particular. My implementation here was to add a different background color on the job container when it is the target.