### PR TITLE
Show the timestamp in the log output

### DIFF
--- a/resources/dl.sh
+++ b/resources/dl.sh
@@ -22,6 +22,7 @@ trap "rm -rf $WORKDIR" EXIT
 
 pushd "$WORKDIR" > /dev/null
 
+echo "Timestamp: $(date -Is)"
 python3 -m venv e
 e/bin/pip --no-color --no-cache-dir --disable-pip-version-check install --progress-bar=off yt-dlp
 e/bin/yt-dlp --flat-playlist -x --audio-quality=0 --no-simulate -O 'id: %(id)s' -O 'title: %(title)s' -O 'original_url: %(original_url)s' --exec echo --newline --no-colors "$URL" | tee log


### PR DESCRIPTION
Just a suggestion: So time context can be exposed to the user

Would look like this:

![image](https://github.com/pb-/ytdlui/assets/2179169/93868ada-0d2e-42af-abcb-339d7d27be73)
